### PR TITLE
Add max retries and test when something has failed with faker image

### DIFF
--- a/database/seeds/PostsMediaSeeder.php
+++ b/database/seeds/PostsMediaSeeder.php
@@ -16,7 +16,15 @@ class PostsMediaSeeder extends Seeder
         $faker = Faker\Factory::create();
         foreach (\App\Post::all() as $post) {
             if(rand(1, 10) > 4){
-                $post->addMedia($faker->image(null, 600, 400))->preservingOriginal()->toCollectionOnDisk('featured', 'local-media');
+                $counter = 0;
+                // max retries = 5 because sometimes faker return false
+                while (!($fakeImage = $faker->image(null, 600, 400)) && ($counter < 5)) {
+                    $counter++;
+                }
+
+                if ($fakeImage !== false) {
+                    $post->addMedia($fakeImage)->preservingOriginal()->toCollectionOnDisk('featured', 'local-media');
+                }
             }
         }
     }


### PR DESCRIPTION
Sometimes build fails because of faker image generator instability. 
I added in PostsMediaSeeder:
 - a "max retries" feature
 - a test before add media